### PR TITLE
Fix usage of undefined safeHeader function

### DIFF
--- a/functions.jsconnect.php
+++ b/functions.jsconnect.php
@@ -83,10 +83,10 @@ function writeJsConnect($user, $request, $clientID, $secret, $secure = true) {
     $json = json_encode($result);
 
     if (isset($request['callback'])) {
-        safeHeader('Content-Type: application/javascript; charset=utf-8', true);
+        header("Content-Type: application/javascript; charset=utf-8", true);
         echo "{$request['callback']}($json)";
     } else {
-        safeHeader('Content-Type: application/json; charset=utf-8', true);
+        header("Content-Type: application/json; charset=utf-8", true);
         echo $json;
     }
 }


### PR DESCRIPTION
A Vanilla function, [`safeHeader`](https://github.com/vanilla/vanilla/blob/7f588055bfabb46d35275e2c3e4f31c62b5562f1/library/core/functions.compatibility.php#L563), managed to find its way into the standalone jsConnect library. Trying to use the library outside Vanilla would lead to undefined-function errors. The function was mainly responsible for performing context checks (e.g. making sure we aren't in CLI mode) and ensuring headers had not already been sent. For now, these checks should be the responsibility of the application, not the library. We're going with standard [`header`](https://www.php.net/manual/en/function.header.php) calls.