### PR TITLE
Fix usage of undefined safeHeader function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,12 @@
 language: php
 
 php:
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
     - 7.1
     - 7.2
-    - hhvm
+    - 7.3
 
 matrix:
-  allow_failures:
-    - php: hhvm
-  fast_finish: true
+    fast_finish: true
 
 install:
     - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,6 @@ matrix:
 
 install:
     - composer self-update
-    - |
-      if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
-          composer require "phpunit/phpunit=~5.7"
-      else
-          if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]]; then
-              composer require "phpunit/phpunit=~5"
-          else
-              composer require "phpunit/phpunit=~4.8"
-          fi
-      fi
-
+    - composer require "phpunit/phpunit=~7.5"
 
 script: ./vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover=coverage.clover

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="tests/phpunit.php"
         >
     <php>

--- a/tests/HashTest.php
+++ b/tests/HashTest.php
@@ -10,7 +10,7 @@ namespace JsConnect\Tests;
 /**
  * Unit tests hashing
  */
-class HashTest extends \PHPUnit_Framework_TestCase {
+class HashTest extends \PHPUnit\Framework\TestCase {
 
     /**
      *  Test {@link jsHash} with no $secure parameter.

--- a/tests/SingJsConnectTest.php
+++ b/tests/SingJsConnectTest.php
@@ -10,7 +10,7 @@ namespace JsConnect\Tests;
 /**
  * Unit tests signJsConnect
  */
-class SignJsConnectTest extends \PHPUnit_Framework_TestCase {
+class SignJsConnectTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @param $data

--- a/tests/WriteJsConnectTest.php
+++ b/tests/WriteJsConnectTest.php
@@ -10,7 +10,7 @@ namespace JsConnect\Tests;
 /**
  * Unit tests signJsConnect
  */
-class WriteJsConnectTest extends \PHPUnit_Framework_TestCase {
+class WriteJsConnectTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @param $user


### PR DESCRIPTION
A Vanilla function, [`safeHeader`](https://github.com/vanilla/vanilla/blob/7f588055bfabb46d35275e2c3e4f31c62b5562f1/library/core/functions.compatibility.php#L563), managed to find its way into the standalone jsConnect library. Trying to use the library outside Vanilla would lead to undefined-function errors. The function was mainly responsible for performing context checks (e.g. making sure we aren't in CLI mode) and ensuring headers had not already been sent. For now, the context check is going to be the responsibility of the application, not the library. We're going with standard [`header`](https://www.php.net/manual/en/function.header.php) calls, conditionally set based on [`headers_sent`](https://www.php.net/headers_sent).

Travis was also woefully broken, so it has been patched to the extent of being functional again. This included dropping support for outdated PHP versions.

### Recommended Testing

1. Setup Vanilla's [stub SSO providers](https://github.com/vanilla/stub-sso-providers).
1. Configure a jsConnect provider on a site, linking to a stub SSO provider.
1. Update the stub SSO provider to use the current version of `functions.jsconnect.php`.
1. Sign-in using the stub SSO provider.
1. Verify proper content types are still being sent in responses (e.g. JavaScript when a callback is provided, otherwise JSON).