### PR TITLE
Add support for nonce re-use

### DIFF
--- a/src/JsConnectServer.php
+++ b/src/JsConnectServer.php
@@ -7,7 +7,6 @@
 
 namespace Vanilla\JsConnect;
 
-use Firebase\JWT\ExpiredException;
 use Firebase\JWT\JWT;
 use Vanilla\JsConnect\Exceptions\InvalidValueException;
 

--- a/tests/JsConnectServerTest.php
+++ b/tests/JsConnectServerTest.php
@@ -115,13 +115,12 @@ class JsConnectServerTest extends TestCase {
      */
     public function testCookieReuse(): void {
         list($_, $cookie) = $this->jsc->generateRequest();
+        sleep(1);
         list($_, $cookie2) = $this->jsc->generateRequest([JsConnectServer::FIELD_COOKIE => $cookie]);
+        $this->assertSame($cookie, $cookie2);
 
-        $decoded = $this->jsc->jwtDecode($cookie);
         $decoded2 = $this->jsc->jwtDecode($cookie2);
-
         $this->assertArrayNotHasKey(JsConnectServer::FIELD_COOKIE, $decoded2, "The cookie should be double encoded.");
-        $this->assertSame($decoded[JsConnectServer::FIELD_NONCE], $decoded2[JsConnectServer::FIELD_NONCE]);
     }
 
     /**


### PR DESCRIPTION
This PR allows `JsConnectServer::generateRequest()` to take a `FIELD_COOKIE` field in order to re-use a cookie from a previous call. This is useful when you have a site that can make several calls to `generateRequest()` and thus create race conditions with nonces.